### PR TITLE
Updated UI Def per MSFT Azure team's comment

### DIFF
--- a/ha/createUiDefinition.json
+++ b/ha/createUiDefinition.json
@@ -241,7 +241,7 @@
             "AdminCredential": "[coalesce(basics('adminCredentials').password,basics('adminCredentials').sshPublicKey)]",
             "VNetNewOrExisting": "[toLower(steps('neo4jConfig').VNet.newOrExisting)]",
             "VNetName": "[steps('neo4jConfig').VNet.name]",
-            "VNetAddressPrefix": "[steps('neo4jConfig').VNet.addressPrefix]",
+            "VNetAddressPrefix": "[steps('neo4jConfig').VNet.addressPrefixes]",
             "SubnetName": "[steps('neo4jConfig').VNet.subnets.cluster.name]",
             "SubnetAddressPrefix": "[steps('neo4jConfig').VNet.subnets.cluster.addressPrefix]",
             "SubnetStartAddress": "[steps('neo4jConfig').VNet.subnets.cluster.startAddress]",


### PR DESCRIPTION
We've been getting reports that customers cannot deploy our Neo4j HA Cluster into a VNet. Microsoft responded with the following:

```
There is a bug in the createUIDef file… The output for that parameter is incorrect, currently it is:

"VNetAddressPrefix": "[steps('neo4jConfig').VNet.addressPrefix]",
And must be:
"VNetAddressPrefix": "[steps('neo4jConfig').VNet.addressPrefixes]",
```